### PR TITLE
Adding hocuspocus

### DIFF
--- a/_data/content.json
+++ b/_data/content.json
@@ -165,6 +165,12 @@
             "author": "Daniel Steigerwald",
             "url": "https://github.com/evoluhq/evolu",
             "icon": "https://github.githubassets.com/favicons/favicon-dark.svg"
+          },
+          {
+            "title": "hocuspocus",
+            "author": "ueberdosis",
+            "url": "https://tiptap.dev/hocuspocus/",
+            "icon": "https://yjs.dev/images/logo/yjs.svg"
           }
         ]
       },


### PR DESCRIPTION
I've been using https://tiptap.dev/hocuspocus as a websocket/centralized  (bring your own database) backend for yjs. 

It would make a good addition to the list.

Note: I couldn't find a stand-alone logo for it. Their logo is always an embedded svg.  So I used the yjs logo.