### PR TITLE
Add bangle.io - a local only note taking web app

### DIFF
--- a/_data/content.json
+++ b/_data/content.json
@@ -307,6 +307,12 @@
             "author": "Grant Forrest",
             "url": "https://gnocchi.club",
             "icon": "https://gnocchi.club/android-chrome-512x512.png"
+          },
+            {
+            "title": "Bangle.io",
+            "author": "Kushan Joshi",
+            "url": "https://bangle.io",
+            "icon": "https://app.bangle.io/icon-transparent_x512.png"
           }
         ]
       }


### PR DESCRIPTION
Bangle.io is a local note taking web app that stores your notes in your file-system in markdown format.

Let me know if you all think this is a good fit for your project listing. 

Source code: https://github.com/bangle-io/bangle-io