### PR TITLE
Add Collabs CRDT library

### DIFF
--- a/_data/content.json
+++ b/_data/content.json
@@ -189,6 +189,12 @@
             "author": "Amazon Web Services",
             "url": "https://docs.amplify.aws/lib/datastore/getting-started/q/platform/js/",
             "icon": "https://d0.awsstatic.com/logos/powered-by-aws-white.png"
+          },
+          {
+            "title": "Collabs",
+            "author": "Composable Systems Lab @ CMU",
+            "url": "https://collabs.readthedocs.io/en/latest/",
+            "icon": "https://collabs.readthedocs.io/en/latest/_static/favicon.ico"
           }
         ]
       },


### PR DESCRIPTION
Collabs is a TypeScript CRDT library designed for collaborative apps, like Yjs and Automerge, but with a focus on strongly-typed data models and extensibility.