### PR TITLE
Fix Discord server invite link

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@ layout: compress
     <aside>
       <div class="heading">
         Join our
-        <a href="https://discord.gg/lfwdev" target="_blank"><img class="discord"
+        <a href="https://discord.gg/ZRrwZxn4rW" target="_blank"><img class="discord"
           src="/assets/images/discord.svg" /></a>
         community and attend
         <a href="https://discord.gg/Sw2zhs6p?event=1102927548079423518"


### PR DESCRIPTION
I've found that the main Discord server invite link is not working. Thankfully the one from the list was correct.
This PR is changing the invite link in the layout of the index page.