### PR TITLE
docs: add benchmarks blogpost

### DIFF
--- a/_data/content.json
+++ b/_data/content.json
@@ -65,7 +65,13 @@
             "author": "@kylemathews",
             "url": "https://bricolage.io/some-notes-on-local-first-development/",
             "icon": "https://bricolage.io/favicon-32x32.png"
-          },          
+          },
+          {
+            "title": "List CRDT Benchmarks",
+            "author": "Vadim @streamich Dalecky",
+            "url": "https://jsonjoy.com/blog/list-crdt-benchmarks",
+            "icon": "https://appsets.jsonjoy.com/branding/logos/64x64-fitted.png"
+          },
         ]
       },
       {


### PR DESCRIPTION
Adds link to "List CRDT Benchmarks" blog post.