### PR TITLE
Add DXOS Composer to Apps to try

### DIFF
--- a/_data/content.json
+++ b/_data/content.json
@@ -474,6 +474,12 @@
             "author": "Strut contributors",
             "url": "https://strut.io",
             "icon": "https://strut.io/favicon.ico"
+          },
+          {
+            "title": "DXOS Composer",
+            "author": "dxos.org",
+            "url": "https://composer.dxos.org",
+            "icon": "https://composer.dxos.org/android-chrome-512x512.png"
           }
         ]
       }


### PR DESCRIPTION
[Composer](https://composer.dxos.org) is a great example of a full-featured local-first app to experience local-first software with.