### PR TITLE
fix: heading date metadata

### DIFF
--- a/_data/heading.json
+++ b/_data/heading.json
@@ -6,7 +6,7 @@
   "meetup": {
     "cal_day": "25",
     "cal_month": "Feb",
-    "date": "Tuesday February 2825, 2025 @ 8AM PST",
+    "date": "Tuesday February 25, 2025 @ 8AM PST",
     "graphic": "/assets/images/meetup23.png",
     "discord_link": "https://discord.gg/lofi-so?event=1343271114574401629",
     "youtube_link": "https://youtube.com/live/MD0hyMmMnD4?feature=share",


### PR DESCRIPTION
RE: #92

 A pretty minor correction, but based on the date from the event, it looks like it should be Feb 25th.