### PR TITLE
Add ZamSync to Syncing data

### DIFF
--- a/_data/content.json
+++ b/_data/content.json
@@ -443,6 +443,12 @@
             "icon": "https://avatars.githubusercontent.com/u/60373862?s=192&v=4"
           },
           {
+            "title": "ZamSync",
+            "author": "Etoile-Bleu",
+            "url": "https://github.com/Etoile-Bleu/ZamSync",
+            "icon": "https://github.githubassets.com/favicons/favicon-dark.svg"
+          },
+          {
             "title": "Zero",
             "author": "Rocicorp",
             "url": "https://zero.rocicorp.dev",
@@ -572,7 +578,7 @@
             "author": "@jmeistrich",
             "url": "https://x.com/jmeistrich",
             "icon": "https://pbs.twimg.com/profile_images/509425693726224384/9TfNlE-Y_400x400.jpeg"
-          },
+          }
         ]
       },
       {
@@ -651,7 +657,7 @@
           },
           {
             "title": "Textorama",
-            "author": "João Melo",
+            "author": "Joao Melo",
             "url": "https://textorama.melo.plus/",
             "icon": "https://textorama.melo.plus/android-chrome-192x192.png"
           },


### PR DESCRIPTION
ZamSync is an offline-first WAL sync engine written in Rust, designed for unreliable networks (clinics on 2G/EDGE in Bhutan).

Key properties:

- Hybrid Logical Clocks (HLC) for causal event ordering
- Version Vector deduplication: only missing events are transmitted
- mTLS mutual authentication, ChaCha20-Poly1305 encryption at rest
- Static binary under 5 MB, cross-compiled for ARM64/ARMv7 (RPi class)
- Bandwidth cap per session, WAL snapshot and retention (expire before date)
- Prometheus metrics endpoint

GitHub: https://github.com/Etoile-Bleu/ZamSync